### PR TITLE
fix: less restrictive feat PR titles

### DIFF
--- a/tagger.py
+++ b/tagger.py
@@ -22,7 +22,7 @@ def tagger():
 		head_sha = payload.get('pull_request', {}).get('head', {}).get('sha', None)
 		title = payload.get('pull_request', {}).get('title', '')
 		body = payload.get('pull_request', {}).get('body', '')
-		if title.startswith('feat:') and head_sha:
+		if title.startswith('feat') and head_sha:
 			status = 'pending'
 			description = 'Documentation required'
 			if docs_link_exists(body):


### PR DESCRIPTION
This matches with PRs with titles "feat*" which includes `feat(context):` as well as `feat:`